### PR TITLE
waitFor must return promise

### DIFF
--- a/lib/utils/element-utils.js
+++ b/lib/utils/element-utils.js
@@ -22,7 +22,7 @@ module.exports = {
   },
 
   waitFor: function (fn, timeout) {
-    session.getDriver().wait(fn, timeout);
+    return session.getDriver().wait(fn, timeout);
   },
 
   alert: function () {


### PR DESCRIPTION
Thus, it's possible to make such flows:
```javascript
homepage.waitFor(function () {
  return button.getAttribute('disabled').then(function (isDisabled) {
    return !isDisabled;
  });
}).then(function () {
  button.click();
});
```