### PR TITLE
Transliterate step name for screenshot file name

### DIFF
--- a/lib/env/session.js
+++ b/lib/env/session.js
@@ -1,4 +1,5 @@
 var webdriver = require('selenium-webdriver'),
+    slugify   = require('transliteration').slugify,
     fs        = require('fs'),
     path      = require('path'),
     url       = require('url'),
@@ -31,7 +32,7 @@ module.exports = {
   },
 
   saveScreenshot: function (name) {
-    var filename = name.replace(/\W+/g, '-').toLowerCase() + '.png';
+    var filename = slugify(name) + '.png';
     driver.takeScreenshot().then(function (data) {
       fs.writeFileSync(path.join(config.resultsDir || 'results', 'screenshots', filename), data, 'base64');
     });

--- a/package.json
+++ b/package.json
@@ -18,16 +18,17 @@
   },
   "main": "lib/moonraker.js",
   "dependencies": {
-    "yadda": "0.11.5",
-    "selenium-webdriver": "2.44.0",
-    "mocha": "2.1.0",
     "chai": "1.10.0",
-    "glob": "4.3.1",
-    "nconf": "0.7.1",
-    "handlebars": "2.0.0",
-    "wrench": "1.5.8",
     "coffee-script": "1.9.0",
-    "jquery": "~1.9.0"
+    "glob": "4.3.1",
+    "handlebars": "2.0.0",
+    "jquery": "~1.9.0",
+    "mocha": "2.1.0",
+    "nconf": "0.7.1",
+    "selenium-webdriver": "2.44.0",
+    "transliteration": "^0.1.1",
+    "wrench": "1.5.8",
+    "yadda": "0.11.5"
   },
   "devDependencies": {
     "bower": "~1.3.12",


### PR DESCRIPTION
Problem is that such step name in Russian:
```gherkin
И ввожу город вылета "Москва"
```
results in `-.png` screenshot filename.

Amazing slygify utility from [transliteration package](https://www.npmjs.com/package/transliteration) produces readable filename for any non-Latin characters, for instance `i-vvozhu-gorod-vyleta-moskva.png`