### PR TITLE
add dynamic config support

### DIFF
--- a/lib/moonraker.js
+++ b/lib/moonraker.js
@@ -1,9 +1,15 @@
 var session     = require('./env/session'),
     Page        = require('./page-object/page'),
     Component   = require('./page-object/component'),
-    nconf       = require('nconf');
+    nconf       = require('nconf'),
+	  fs = require('fs');
 
-nconf.argv().env().file('config.json');
+if (fs.existsSync('../../../dynamic-config')) {
+	var customConfig = require('../../../dynamic-config');
+	nconf.overrides(customConfig).argv().env().file('config.json');
+} else {
+	nconf.argv().env().file('config.json');
+}
 
 exports = module.exports = {
   config:    nconf.get(),


### PR DESCRIPTION
I've been using moonraker at work and I love it. Great work guys. The only thing so far that I was unable to find support for is to generate a complex config out of command prompt flags. For this I used the nconf.override and a dynamic-config js file. This is currently by naming convention, and if such file is located it will be used to assemble a config object which trumps the other configs. If it isn't not located there is no effect  at all, so no risk.

Here's an example where I used nopt in my dynamic config to generate my browserstack configs:

```
var nopt = require("nopt"),
    knownOpts = {
      "target": [String, null],
      "type": [String, null],
      "tags": [String, null],
      "platform": [String, null],
      "browser": [String, null]
    },
    shortHands = {},
    parsed = nopt(knownOpts, shortHands, process.argv, 2);

var config = {
    browser: {}
  };

if (parsed.browser) {
  config.browser.browserName = parsed.browser;
}

if (parsed.target === 'qa') {
  config.baseUrl = 'http://www.qa.domain.com/';
} else if (parsed.target === 'prod') {
  config.baseUrl = 'http://www.domain.com';
}

if (parsed.platform === 'browserstack') {
  config.seleniumServer = 'http://hub.browserstack.com/wd/hub';

  config.browser['browserstack.user'] = '****$@$@';
  config.browser['browserstack.key'] = '**$$@*@$';

  if (parsed.target === 'qa') {
    config.browser['browserstack.local'] = 'true';
  }
};

exports = module.exports = config;
```

Now by allowing this dynamic config, I am able to write a `runtests` script which launches browserstack configurations for all the supported browsers my company requires.